### PR TITLE
chore(deps): bump https://github.com/novadev/auth.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -10,3 +10,4 @@ Dependency | Sources | Version | Mismatched versions
 [novadev/notification](https://github.com/novadev/notification.git) |  | []() | 
 [novadev/pdfops](https://github.com/novadev/pdfops.git) |  | []() | 
 [novadev/proto-scala](https://github.com/novadev/proto-scala.git) |  | []() | 
+[novadev/auth](https://github.com/novadev/auth.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -47,3 +47,9 @@ dependencies:
   url: https://github.com/novadev/proto-scala.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: novadev
+  repo: auth
+  url: https://github.com/novadev/auth.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/novadev-auth-sr.yaml
+++ b/repositories/templates/novadev-auth-sr.yaml
@@ -2,7 +2,7 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "15"
+    jenkins.io/last-build-number-for-master: "16"
   creationTimestamp: null
   labels:
     owner: novadev

--- a/repositories/templates/novadev-auth-sr.yaml
+++ b/repositories/templates/novadev-auth-sr.yaml
@@ -2,7 +2,7 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "7"
+    jenkins.io/last-build-number-for-master: "8"
   creationTimestamp: null
   labels:
     owner: novadev
@@ -13,7 +13,9 @@ metadata:
     fieldsType: FieldsV1
     fieldsV1:
       f:metadata:
-        f:annotations: {}
+        f:annotations:
+          .: {}
+          f:jenkins.io/last-build-number-for-master: {}
         f:labels:
           .: {}
           f:owner: {}
@@ -35,16 +37,7 @@ metadata:
         f:url: {}
     manager: jx
     operation: Update
-    time: "2021-08-01T09:08:22Z"
-  - apiVersion: jenkins.io/v1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:annotations:
-          f:jenkins.io/last-build-number-for-master: {}
-    manager: lighthouse-jx-controller
-    operation: Update
-    time: "2021-08-01T09:10:09Z"
+    time: "2021-08-01T09:13:43Z"
   name: novadev-auth
 spec:
   description: Imported application for novadev/auth

--- a/repositories/templates/novadev-auth-sr.yaml
+++ b/repositories/templates/novadev-auth-sr.yaml
@@ -2,7 +2,7 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "14"
+    jenkins.io/last-build-number-for-master: "15"
   creationTimestamp: null
   labels:
     owner: novadev
@@ -13,7 +13,9 @@ metadata:
     fieldsType: FieldsV1
     fieldsV1:
       f:metadata:
-        f:annotations: {}
+        f:annotations:
+          .: {}
+          f:jenkins.io/last-build-number-for-master: {}
         f:labels:
           .: {}
           f:owner: {}
@@ -35,16 +37,7 @@ metadata:
         f:url: {}
     manager: jx
     operation: Update
-    time: "2021-08-01T09:52:02Z"
-  - apiVersion: jenkins.io/v1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:annotations:
-          f:jenkins.io/last-build-number-for-master: {}
-    manager: lighthouse-jx-controller
-    operation: Update
-    time: "2021-08-01T09:56:45Z"
+    time: "2021-08-01T09:57:00Z"
   name: novadev-auth
 spec:
   description: Imported application for novadev/auth

--- a/repositories/templates/novadev-auth-sr.yaml
+++ b/repositories/templates/novadev-auth-sr.yaml
@@ -1,0 +1,48 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: novadev
+    provider: github
+    repository: auth
+  managedFields:
+  - apiVersion: jenkins.io/v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:owner: {}
+          f:provider: {}
+          f:repository: {}
+      f:spec:
+        .: {}
+        f:description: {}
+        f:httpCloneURL: {}
+        f:org: {}
+        f:provider: {}
+        f:providerKind: {}
+        f:providerName: {}
+        f:repo: {}
+        f:scheduler:
+          .: {}
+          f:kind: {}
+          f:name: {}
+        f:url: {}
+    manager: jx
+    operation: Update
+    time: "2021-08-01T07:32:32Z"
+  name: novadev-auth
+spec:
+  description: Imported application for novadev/auth
+  httpCloneURL: https://github.com/novadev/auth.git
+  org: novadev
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: auth
+  scheduler:
+    kind: ""
+    name: ""
+  url: git@github.com:novadev/auth.git

--- a/repositories/templates/novadev-auth-sr.yaml
+++ b/repositories/templates/novadev-auth-sr.yaml
@@ -2,7 +2,7 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "2"
+    jenkins.io/last-build-number-for-master: "5"
   creationTimestamp: null
   labels:
     owner: novadev
@@ -35,7 +35,7 @@ metadata:
         f:url: {}
     manager: jx
     operation: Update
-    time: "2021-08-01T08:57:32Z"
+    time: "2021-08-01T09:01:48Z"
   - apiVersion: jenkins.io/v1
     fieldsType: FieldsV1
     fieldsV1:
@@ -44,7 +44,7 @@ metadata:
           f:jenkins.io/last-build-number-for-master: {}
     manager: lighthouse-jx-controller
     operation: Update
-    time: "2021-08-01T09:01:29Z"
+    time: "2021-08-01T09:02:39Z"
   name: novadev-auth
 spec:
   description: Imported application for novadev/auth

--- a/repositories/templates/novadev-auth-sr.yaml
+++ b/repositories/templates/novadev-auth-sr.yaml
@@ -2,7 +2,7 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "10"
+    jenkins.io/last-build-number-for-master: "12"
   creationTimestamp: null
   labels:
     owner: novadev
@@ -35,7 +35,7 @@ metadata:
         f:url: {}
     manager: jx
     operation: Update
-    time: "2021-08-01T09:13:43Z"
+    time: "2021-08-01T09:43:41Z"
   - apiVersion: jenkins.io/v1
     fieldsType: FieldsV1
     fieldsV1:
@@ -44,7 +44,7 @@ metadata:
           f:jenkins.io/last-build-number-for-master: {}
     manager: lighthouse-jx-controller
     operation: Update
-    time: "2021-08-01T09:43:24Z"
+    time: "2021-08-01T09:51:47Z"
   name: novadev-auth
 spec:
   description: Imported application for novadev/auth

--- a/repositories/templates/novadev-auth-sr.yaml
+++ b/repositories/templates/novadev-auth-sr.yaml
@@ -2,7 +2,7 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "8"
+    jenkins.io/last-build-number-for-master: "10"
   creationTimestamp: null
   labels:
     owner: novadev
@@ -13,9 +13,7 @@ metadata:
     fieldsType: FieldsV1
     fieldsV1:
       f:metadata:
-        f:annotations:
-          .: {}
-          f:jenkins.io/last-build-number-for-master: {}
+        f:annotations: {}
         f:labels:
           .: {}
           f:owner: {}
@@ -38,6 +36,15 @@ metadata:
     manager: jx
     operation: Update
     time: "2021-08-01T09:13:43Z"
+  - apiVersion: jenkins.io/v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          f:jenkins.io/last-build-number-for-master: {}
+    manager: lighthouse-jx-controller
+    operation: Update
+    time: "2021-08-01T09:43:24Z"
   name: novadev-auth
 spec:
   description: Imported application for novadev/auth

--- a/repositories/templates/novadev-auth-sr.yaml
+++ b/repositories/templates/novadev-auth-sr.yaml
@@ -2,7 +2,7 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "12"
+    jenkins.io/last-build-number-for-master: "14"
   creationTimestamp: null
   labels:
     owner: novadev
@@ -35,7 +35,7 @@ metadata:
         f:url: {}
     manager: jx
     operation: Update
-    time: "2021-08-01T09:43:41Z"
+    time: "2021-08-01T09:52:02Z"
   - apiVersion: jenkins.io/v1
     fieldsType: FieldsV1
     fieldsV1:
@@ -44,7 +44,7 @@ metadata:
           f:jenkins.io/last-build-number-for-master: {}
     manager: lighthouse-jx-controller
     operation: Update
-    time: "2021-08-01T09:51:47Z"
+    time: "2021-08-01T09:56:45Z"
   name: novadev-auth
 spec:
   description: Imported application for novadev/auth

--- a/repositories/templates/novadev-auth-sr.yaml
+++ b/repositories/templates/novadev-auth-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "2"
   creationTimestamp: null
   labels:
     owner: novadev
@@ -11,6 +13,7 @@ metadata:
     fieldsType: FieldsV1
     fieldsV1:
       f:metadata:
+        f:annotations: {}
         f:labels:
           .: {}
           f:owner: {}
@@ -32,7 +35,16 @@ metadata:
         f:url: {}
     manager: jx
     operation: Update
-    time: "2021-08-01T07:32:32Z"
+    time: "2021-08-01T08:57:32Z"
+  - apiVersion: jenkins.io/v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          f:jenkins.io/last-build-number-for-master: {}
+    manager: lighthouse-jx-controller
+    operation: Update
+    time: "2021-08-01T09:01:29Z"
   name: novadev-auth
 spec:
   description: Imported application for novadev/auth

--- a/repositories/templates/novadev-auth-sr.yaml
+++ b/repositories/templates/novadev-auth-sr.yaml
@@ -2,7 +2,7 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "5"
+    jenkins.io/last-build-number-for-master: "7"
   creationTimestamp: null
   labels:
     owner: novadev
@@ -35,7 +35,7 @@ metadata:
         f:url: {}
     manager: jx
     operation: Update
-    time: "2021-08-01T09:01:48Z"
+    time: "2021-08-01T09:08:22Z"
   - apiVersion: jenkins.io/v1
     fieldsType: FieldsV1
     fieldsV1:
@@ -44,7 +44,7 @@ metadata:
           f:jenkins.io/last-build-number-for-master: {}
     manager: lighthouse-jx-controller
     operation: Update
-    time: "2021-08-01T09:02:39Z"
+    time: "2021-08-01T09:10:09Z"
   name: novadev-auth
 spec:
   description: Imported application for novadev/auth


### PR DESCRIPTION
Update [novadev/auth](https://github.com/novadev/auth.git) 

Command run was `jx import --no-draft`
<hr />

Update [novadev/auth](https://github.com/novadev/auth.git) 

Command run was `jx import --no-draft`
<hr />

Update [novadev/auth](https://github.com/novadev/auth.git) 

Command run was `jx import --no-draft`
<hr />

Update [novadev/auth](https://github.com/novadev/auth.git) 

Command run was `jx import --no-draft`
<hr />

Update [novadev/auth](https://github.com/novadev/auth.git) 

Command run was `jx import --no-draft`
<hr />

Update [novadev/auth](https://github.com/novadev/auth.git) 

Command run was `jx import --no-draft`
<hr />

Update [novadev/auth](https://github.com/novadev/auth.git) 

Command run was `jx import --no-draft`
<hr />

Update [novadev/auth](https://github.com/novadev/auth.git) 

Command run was `jx import --no-draft`
<hr />

Update [novadev/auth](https://github.com/novadev/auth.git) 

Command run was `jx import --no-draft`
<hr />

Update [novadev/auth](https://github.com/novadev/auth.git) 

Command run was `jx import --no-draft`